### PR TITLE
ms013g: Fix probing of the ram console

### DIFF
--- a/drivers/staging/android/ram_console.c
+++ b/drivers/staging/android/ram_console.c
@@ -55,6 +55,7 @@ static int __devinit ram_console_probe(struct platform_device *pdev)
 	struct ram_console_platform_data *pdata = pdev->dev.platform_data;
 	struct persistent_ram_zone *prz;
 
+	pdev->dev.init_name = "ram_console";
 	prz = persistent_ram_init_ringbuffer(&pdev->dev, true);
 	if (IS_ERR(prz))
 		return PTR_ERR(prz);
@@ -74,9 +75,15 @@ static int __devinit ram_console_probe(struct platform_device *pdev)
 	return 0;
 }
 
+static struct of_device_id msm_match_table[] = {
+	{.compatible = "ram_console"},
+	{},
+};
+
 static struct platform_driver ram_console_driver = {
 	.driver		= {
 		.name	= "ram_console",
+		.of_match_table = msm_match_table,
 	},
 	.probe = ram_console_probe,
 };


### PR DESCRIPTION
This fixes last_kmsg
Original commit :
CyanogenMod/android_kernel_samsung_hlte@a44fd9d